### PR TITLE
More robust `deleteAll`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Simplistic node redis cache ready can scale with generic-pool support
 ## Prerequisites
 
 ```node >= 4``` This module requires nodejs v4 or above as it has dependencies on es6 components such as Map, Set, Promise etc.
+```redis >= 4``` This module requires redis v4 or above as it has dependencies on `UNLINK` and `redis.replicate_commands()` for pattern deletion.
 
 ## Featuring
 - Out of the box default configuration (but fully configurable)

--- a/lib/redis_cache.js
+++ b/lib/redis_cache.js
@@ -82,14 +82,14 @@ RedisCache.prototype.keys = function (pattern) {
  * Deletes all keys matching pattern
  *
  * @param {string} pattern - glob-style patterns/default '*'
- * @returns {array} The number of keys that were removed.
+ * @returns {number} The number of keys that were removed.
  */
 RedisCache.prototype.deleteAll = function (pattern) {
   if (!pattern || pattern === "") {
     pattern = "*";
   }
 
-  return this.store.deleteAll();
+  return this.store.deleteAll(pattern);
 };
 
 /**

--- a/lib/redis_store.js
+++ b/lib/redis_store.js
@@ -147,7 +147,7 @@ RedisStore.prototype.get = function (key) {
 RedisStore.prototype.set = function (key, value, ttlInSeconds) {
   value = Array.isArray(value) || isJSON(value, true) ? JSON.stringify(value) : value;
 
-  if (! ttlInSeconds) {
+  if (!ttlInSeconds) {
     ttlInSeconds = this.ttlInSeconds;
   }
   if (ttlInSeconds) {
@@ -206,25 +206,14 @@ RedisStore.prototype.keys = function (pattern) {
  * Deletes all keys matching pattern
  *
  * @param {string} pattern - glob-style patterns/default '*'
- * @returns {array} The number of keys that were removed.
+ * @returns {number} The number of keys that were removed.
  */
 RedisStore.prototype.deleteAll = function (pattern) {
   if (!pattern || pattern === "") {
     pattern = "*";
   }
   debug("clearing redis keys: ", pattern);
-
-  return this.keys(pattern)
-    .then(keys => {
-
-      if (keys.length > 0) {
-        debug("deleting keys ", keys);
-        return this.del(keys);
-      } else {
-        debug("no keys exists with pattern: ", pattern);
-        return Promise.resolve(true);
-      }
-    });
+  return this._executeDeleteAll(pattern);
 };
 
 /**
@@ -234,4 +223,56 @@ RedisStore.prototype.deleteAll = function (pattern) {
  */
 RedisStore.prototype.status = function () {
   return this.pool.status();
+};
+
+/**
+ * Preloads delete all scripts into redis script cache
+ * (this script requires redis >=  4.0.0)
+ * @async
+ * @returns {Promise<string>} sha1 hash of preloaded function
+ * @private
+ */
+RedisStore.prototype._loadDeleteAllScript = function () {
+  if (!this.__deleteScriptPromise) {
+    const deleteKeysScript = `
+    local keys = {};
+    local done = false;
+    local cursor = "0";
+    local deleted = 0;
+    redis.replicate_commands();
+    repeat
+        local result = redis.call("SCAN", cursor, "match", ARGV[1], "count", ARGV[2])
+        cursor = result[1];
+        keys = result[2];
+        for i, key in ipairs(keys) do
+            deleted = deleted + redis.call("UNLINK", key);
+        end
+        if cursor == "0" then
+            done = true;
+        end
+    until done
+    return deleted;`;
+    this.__deleteScriptPromise = this.sendCommand("SCRIPT", ["LOAD", deleteKeysScript]);
+  }
+  return this.__deleteScriptPromise;
+};
+
+/**
+ * Preloads and execute delete all script
+ * @async
+ * @param {string} pattern - glob-style patterns/default '*'
+ * @returns {Promise<number>} The number of keys that were removed.
+ * @private
+ */
+RedisStore.prototype._executeDeleteAll = function (pattern) {
+  return this._loadDeleteAllScript()
+    .then(sha1 => this.sendCommand("EVALSHA", [sha1, 0, pattern, 1000]))
+    .catch(err => {
+      if (err.code === "NOSCRIPT") {
+        // We can get here only if server is restarted somehow and cache is deleted
+        this.__deleteScriptPromise = null;
+        return this._executeDeleteAll(pattern);
+      }
+      throw err;
+    });
 };

--- a/test/redis_cache.js
+++ b/test/redis_cache.js
@@ -175,13 +175,20 @@ describe("redisCache", () => {
       const keyValues = {key1: "value1", key2: "value2"};
 
       beforeEach(() => Promise.all(Object.keys(keyValues)
-          .map(key => cache.set(key, keyValues[key]))));
+        .map(key => cache.set(key, keyValues[key]))));
 
       it("should delete all the keys", () => {
 
         return cache.deleteAll()
           .then(() => cache.keys())
           .should.eventually.be.empty();
+      });
+
+      it("should delete all the keys with pattern", () => {
+
+        return cache.deleteAll("key1*")
+          .then(() => cache.keys())
+          .should.eventually.be.eql(["key2"]);
       });
     });
 

--- a/test/redis_store.js
+++ b/test/redis_store.js
@@ -366,7 +366,7 @@ describe("redisStore", () => {
     it("should delete all the keys", () => {
 
       return store.deleteAll()
-        .then(v => v.should.be.ok())
+        .then(v => v.should.be.eql(2))
         .then(() => store.keys())
         .should.eventually.be.empty();
     });
@@ -375,7 +375,7 @@ describe("redisStore", () => {
 
       return store.deleteAll("key[2]")
         .then(v => {
-          v.should.be.ok();
+          v.should.be.eql(1);
         })
         .then(() => store.keys())
         .should.eventually.be.not.empty()
@@ -386,10 +386,10 @@ describe("redisStore", () => {
 
       return store.deleteAll()
         .then(v => {
-          v.should.be.ok();
+          v.should.be.eql(2);
         })
         .then(() => store.deleteAll("nonExistingKey"))
-        .should.eventually.be.ok();
+        .should.eventually.be.eql(0);
     });
   });
 });

--- a/test/redis_store.js
+++ b/test/redis_store.js
@@ -391,5 +391,16 @@ describe("redisStore", () => {
         .then(() => store.deleteAll("nonExistingKey"))
         .should.eventually.be.eql(0);
     });
+
+    it("should delete if function is deleted from cache", () => {
+
+      return store.deleteAll()
+        .then(v => {
+          v.should.be.eql(2);
+        })
+        .then(() => store.sendCommand("script",["flush"]))
+        .then(() => store.deleteAll())
+        .should.eventually.be.eql(0);
+    });
   });
 });


### PR DESCRIPTION
As you may have noticed current implementation first gets all `KEYS` and then issue a `DEL` command, this is slow and frequently fails on a large number of keys.
This PR is using LUA script to `SCAN` for matched keys in portions of 1000 and then `UNLINK` them (async `DEL` command)

Also there was a bug in https://github.com/pasupulaphani/node-cache-redis/compare/master...arusanovt:master#diff-4048fe793500ebbb7a3a2054f1bdfbe5R92 `pattern` wasn't passed to store so all keys got deleted always