### PR TITLE
Fixes for RedisCache set and keys functions

### DIFF
--- a/lib/redis_cache.js
+++ b/lib/redis_cache.js
@@ -75,7 +75,7 @@ RedisCache.prototype.keys = function (pattern) {
     pattern = "*";
   }
 
-  return this.store.keys();
+  return this.store.keys(pattern);
 };
 
 /**

--- a/lib/redis_cache.js
+++ b/lib/redis_cache.js
@@ -49,7 +49,8 @@ RedisCache.prototype.getTtl = function (ttlInSeconds) {
  * @returns {string} 'OK' if successful
  */
 RedisCache.prototype.set = function (key, value, ttlInSeconds) {
-  if (this.getTtl(ttlInSeconds) === 0) return Promise.resolve(value);
+  ttlInSeconds = this.getTtl(ttlInSeconds);
+  if (ttlInSeconds === 0) return Promise.resolve(value);
 
   return this.store.set(key, value, ttlInSeconds);
 };


### PR DESCRIPTION
The RedisCache set prototype function was ignoring the default ttlInSeconds if the ttlInSeconds parameter passed was null.  Also, the RedisCache keys prototype function was completely ignoring the pattern parameter other than setting a default value for it.